### PR TITLE
Fix warning message in bridge

### DIFF
--- a/voyager/env/bridge.py
+++ b/voyager/env/bridge.py
@@ -29,7 +29,7 @@ class VoyagerEnv(gym.Env):
             raise ValueError("Either mc_port or azure_login must be specified")
         if mc_port and azure_login:
             warnings.warn(
-                "Both mc_port and mc_login are specified, mc_port will be ignored"
+                "Both mc_port and azure_login are specified, mc_port will be ignored"
             )
         self.mc_port = mc_port
         self.azure_login = azure_login


### PR DESCRIPTION
## Summary
- fix typo in warning when both mc_port and azure_login are used

## Testing
- `python -m py_compile voyager/env/bridge.py`

------
https://chatgpt.com/codex/tasks/task_e_68465a7670a8832987774051752102ec