### PR TITLE
Add missing import

### DIFF
--- a/voyager/utils/record_utils.py
+++ b/voyager/utils/record_utils.py
@@ -1,4 +1,5 @@
 import time
+import re
 
 from .file_utils import *
 from .json_utils import *


### PR DESCRIPTION
## Summary
- add `import re` in `record_utils`
- verify `EventRecorder.record` works

## Testing
- `python -m pytest`
- `python - <<'PY' ...`

------
https://chatgpt.com/codex/tasks/task_e_68465a724304832984d3e53bdc23fa57